### PR TITLE
`Permutation`, `CyclePermutation`

### DIFF
--- a/src/AbstractPermutations.jl
+++ b/src/AbstractPermutations.jl
@@ -3,7 +3,7 @@ module AbstractPermutations
 import ..GroupElement
 import ..orbit_plain
 
-export AbstractPermutation, degree, cycle_decomposition
+export AbstractPermutation, degree
 
 """
     AbstractPermutation

--- a/src/AbstractPermutations.jl
+++ b/src/AbstractPermutations.jl
@@ -3,7 +3,7 @@ module AbstractPermutations
 import ..GroupElement
 import ..orbit_plain
 
-export AbstractPermutation, degree
+export AbstractPermutation, degree, cycle_decomposition
 
 """
     AbstractPermutation

--- a/src/CGT_UniHeidelberg_2022.jl
+++ b/src/CGT_UniHeidelberg_2022.jl
@@ -7,5 +7,6 @@ include("AbstractPermutations.jl")
 using .AbstractPermutations
 
 include("permutations.jl")
+include("permutations_02.jl")
 
 end # of module CGT_UniHeidelberg_2022

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -99,8 +99,9 @@ function degree(σ::CyclePermutation)
     # it then suffices to take the maximum element in each cycle,
     # and again take the maximum over these cycles for the degree.
     deg = 1
+    non_trivial_cycles = filter(c->length(c)>=2, σ.cycles)
     if length(σ.cycles) >= 1
-        deg = mapreduce(maximum, max, σ.cycles; init=deg)
+        deg = mapreduce(maximum, max, non_trivial_cycles; init=deg)
     end
     return deg
 end

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -63,7 +63,7 @@ struct CyclePermutation <: AbstractPermutation
     function CyclePermutation(v::AbstractVector{<:Integer}, check=true)
         # Construct temporary for cycle decomposition
         σ = Permutation(v, check)
-        cycles = cycle_decomposition(σ)
+        cycles = AbstractPermutations.cycle_decomposition(σ)
 
         # We assume that `cycle_decomposition()` returns a product of
         # disjoint cycles. The implementation in `AbstractPermutations`

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -36,3 +36,84 @@ function degree(σ::Permutation)
 end
 export degree
 
+
+""" Exercise #1
+Create struct `CyclePermutation <: AbstractPermutation` that stores
+`cycles::Vector{Vector{Int}}` in its fields.
+
+* Implement the `AbstractPermutation` interface i.e. degree and obtaining
+  the image of `i::Integer` under such permutation.
+* Verify the correctness of multiplication, inversion etc. by writing
+  appropriate begin ... end block with `@asserts`.
+* What happens if we multiply `CyclePermutation` and `Permutation` together?
+  Can you find where does this behaviour come from?
+"""
+struct CyclePermutation <: AbstractPermutation
+    # Store the cyclic decomposition of the permutation.
+    cycles::Vector{Vector{Int}}
+
+    # Since we want to compute σ(i) with O(1) complexity, the simplest
+    # way is to also store the vector of images. Computing σ(i) from a
+    # cyclic decomposition (with disjoint cycles) would require finding
+    # the cycle which contains the index i. Cycles are not necessarily
+    # sorted, so this would result in O(N) complexity.
+    images::Vector{Int}
+
+    function Permutation(v::AbstractVector{<:Integer}, check=true)
+        # Construct temporary Permutation for cycle decomposition
+        σ = Permutation(v, check)
+        c = cycle_decomposition(σ)
+
+        # We assume that `cycle_decomposition()` returns a product of
+        # disjoint cycles. The implementation in `AbstractPermutations`
+        # achieves this by computing orbits (which are either identical
+        # or disjoint).
+        if check
+            σ_cat = Int[]
+            for c ∈ cycles
+                σ_cat = vcat(σ_cat, c)
+            end
+            @assert allunique(σ_cat) "σ is not a decomposition in disjoint cycles"
+        end
+        new(c, σ) # inner constructor method
+    end
+end
+
+# Since σ stores both the images and the cycles (see comment above), the
+# implementation equals the one for σ::Permutation.
+# XXX: CyclePermutation is not a subtype of Permutation. Can the
+# implementation for `σ::Permutation` still be assigned here?
+# If not, this could be a "detail" called by (σ::Permutation)(n) and
+# (σ::CyclePermutation)(n).
+function (σ::CyclePermutation)(n::Integer)
+    if n > length(σ.images)
+        return convert(Int, n)
+    else
+        return σ.images[n]
+    end
+end
+
+function degree(σ::CyclePermutation)
+    # Cycles of length k>=2 have no elements mapped to themselves;
+    # it then suffices to take the maximum element in each cycle,
+    # and again take the maximum over these cycles for the degree.
+    deg = 1
+    for c ∈ σ.cycles
+        if max(c) > deg
+            deg = max(c)
+        end
+    end
+    return deg
+end
+export degree
+
+# `cycle_decomposition()` can be specialized for `CyclePermutation`, in
+# the sense that the operation becomes trivial (the decomposition is
+# already part of the object). This avoids redundant computations when
+# serializing the permutation (`Base.show()`).
+function cycle_decomposition(σ::CyclePermutation)
+    return σ.cycles
+end
+export cycle_decomposition
+
+# end # of Permutation

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -1,0 +1,38 @@
+#module Permutation
+# included from CGT_UniHeidelberg_2022.jl
+
+#export Permutation, CyclicPermutation
+
+""" Exercise #1
+`Permutation` as implementation of abstract type `AbstractPermutation`.
+"""
+struct Permutation <: AbstractPermutation
+    images::Vector{Int}
+
+    function Permutation(v::AbstractVector{<:Integer}, check=true)
+        if check
+            @assert sort(v) == 1:length(v) "Image vector doesn't define a permutation"
+        end
+        return new(v) # calls convert(Vector{Int}, v)
+    end
+end
+
+function (σ::Permutation)(n::Integer)
+    if n > length(σ.images)
+        return convert(Int, n)
+    else
+        return σ.images[n]
+    end
+end
+
+function degree(σ::Permutation)
+    n = length(σ.images)
+    for i in n:-1:1  # reverse in steps by -1
+        if σ.images[i] != i
+            return i
+        end
+    end
+    return 1
+end
+export degree
+

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -119,15 +119,18 @@ end
 Parse permutations from a string, with cycles delimited by braces.
 Cycles are not required to be disjoint.
 """
-# Easy way: use a perl-compatible regex with `eachmatch`. The problem
-# with the function below is that no kind of error checking is done -
-# whatever matches a valid cycle is returned. Turning the cycles into an
-# expression can be done in the same way as `Meta.parse` does below.
+# Easy way: use a perl-compatible regex with `eachmatch`. Input
+# validation is done by concatenating each match, and checking if the
+# original string is recovered. However, only a generic error message is
+# returned on invalid input. Turning the cycles into an expression can
+# be done in the same way as `Meta.parse` does below.
 function string_to_cycles(str::AbstractString)
     cycles = Vector{Vector{Int}}(undef, 0)
+    str_reconstructed = ""
 
     for m in eachmatch(r"\(\d+(?:,\d+)*\)", str)
         str_cycle = m.match
+        str_reconstructed *= str_cycle
         current_cycle = Int[]
 
         for m_num in eachmatch(r"\d+(?=[,\)])", str_cycle)
@@ -136,6 +139,11 @@ function string_to_cycles(str::AbstractString)
             push!(current_cycle, num)
         end
         push!(cycles, copy(current_cycle))
+    end
+
+    # Basic input validation with generic error message
+    if str_reconstructed != str
+        throw(Meta.ParseError)
     end
     return cycles
 end

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -1,6 +1,7 @@
 # included from CGT_UniHeidelberg_2022.jl
 
 export Permutation, CyclePermutation, degree, cycle_decomposition
+export string_to_cycles, string_to_cycles_regexp
 
 import ..degree
 import ..cycle_decomposition
@@ -146,7 +147,6 @@ function string_to_cycles_regexp(str::AbstractString)
     end
     return cycles
 end
-export string_to_cycles_regexp
 
 # Hard way: implement a FSM by hand. Has detailed error messages for
 # wrong inputs.
@@ -210,7 +210,6 @@ function string_to_cycles(str::AbstractString)
     end
     return cycles
 end
-export string_to_cycles
 
 # Turn cycles into an expression
 # XXX: this makes no specific assumptions on the implementation of

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -99,10 +99,8 @@ function degree(σ::CyclePermutation)
     # it then suffices to take the maximum element in each cycle,
     # and again take the maximum over these cycles for the degree.
     deg = 1
-    for c ∈ σ.cycles
-        if maximum(c) > deg
-            deg = maximum(c)
-        end
+    if length(σ.cycles) >= 1
+        deg = mapreduce(maximum, max, σ.cycles; init=deg)
     end
     return deg
 end

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -122,9 +122,8 @@ Cycles are not required to be disjoint.
 # Easy way: use a perl-compatible regex with `eachmatch`. Input
 # validation is done by concatenating each match, and checking if the
 # original string is recovered. However, only a generic error message is
-# returned on invalid input. Turning the cycles into an expression can
-# be done in the same way as `Meta.parse` does below.
-function string_to_cycles(str::AbstractString)
+# returned on invalid input.
+function string_to_cycles_regexp(str::AbstractString)
     cycles = Vector{Vector{Int}}(undef, 0)
     str_reconstructed = ""
 
@@ -147,14 +146,11 @@ function string_to_cycles(str::AbstractString)
     end
     return cycles
 end
-export string_to_cycles
+export string_to_cycles_regexp
 
 # Hard way: implement a FSM by hand. Has detailed error messages for
 # wrong inputs.
-# XXX: this makes no specific assumptions on the implementation of
-# AbstractPermutation, but using ::Type{P} ... where
-# P<:AbstractPermutation results in `UndefVarError: P not defined`.
-function Meta.parse(::Type{Permutation}, str::AbstractString)
+function string_to_cycles(str::AbstractString)
     in_cycle, in_number = false, false
     cycles = Vector{Vector{Int}}(undef, 0)
     current_cycle = Int[]
@@ -212,8 +208,16 @@ function Meta.parse(::Type{Permutation}, str::AbstractString)
     if in_cycle == true
         throw(Meta.ParseError("cycle is unterminated"))
     end
+    return cycles
+end
+export string_to_cycles
 
-    # Turn cycles into an expression
+# Turn cycles into an expression
+# XXX: this makes no specific assumptions on the implementation of
+# AbstractPermutation, but using ::Type{P} ... where
+# P<:AbstractPermutation results in `UndefVarError: P not defined`.
+function Meta.parse(::Type{Permutation}, str::AbstractString)
+    cycles = string_to_cycles(str)
     if length(cycles) == 0
         return :(Permutation(Int[]))
     end

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -1,7 +1,9 @@
-#module Permutation
 # included from CGT_UniHeidelberg_2022.jl
 
-#export Permutation, CyclicPermutation
+export Permutation, CyclePermutation, degree, cycle_decomposition
+
+import ..degree
+import ..cycle_decomposition
 
 """ Exercise #1
 `Permutation` as implementation of abstract type `AbstractPermutation`.
@@ -34,8 +36,6 @@ function degree(σ::Permutation)
     end
     return 1
 end
-export degree
-
 
 """ Exercise #1
 Create struct `CyclePermutation <: AbstractPermutation` that stores
@@ -59,10 +59,10 @@ struct CyclePermutation <: AbstractPermutation
     # sorted, so this would result in O(N) complexity.
     images::Vector{Int}
 
-    function Permutation(v::AbstractVector{<:Integer}, check=true)
+    function CyclePermutation(v::AbstractVector{<:Integer}, check=true)
         # Construct temporary Permutation for cycle decomposition
         σ = Permutation(v, check)
-        c = cycle_decomposition(σ)
+        cycles = cycle_decomposition(σ)
 
         # We assume that `cycle_decomposition()` returns a product of
         # disjoint cycles. The implementation in `AbstractPermutations`
@@ -75,7 +75,7 @@ struct CyclePermutation <: AbstractPermutation
             end
             @assert allunique(σ_cat) "σ is not a decomposition in disjoint cycles"
         end
-        new(c, σ) # inner constructor method
+        new(cycles, σ.images) # inner constructor method
     end
 end
 
@@ -99,13 +99,12 @@ function degree(σ::CyclePermutation)
     # and again take the maximum over these cycles for the degree.
     deg = 1
     for c ∈ σ.cycles
-        if max(c) > deg
-            deg = max(c)
+        if max(c...) > deg
+            deg = max(c...)
         end
     end
     return deg
 end
-export degree
 
 # `cycle_decomposition()` can be specialized for `CyclePermutation`, in
 # the sense that the operation becomes trivial (the decomposition is
@@ -114,6 +113,5 @@ export degree
 function cycle_decomposition(σ::CyclePermutation)
     return σ.cycles
 end
-export cycle_decomposition
 
-# end # of Permutation
+# end # of Permutations

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -61,7 +61,7 @@ struct CyclePermutation <: AbstractPermutation
     images::Vector{Int}
 
     function CyclePermutation(v::AbstractVector{<:Integer}, check=true)
-        # Construct temporary Permutation for cycle decomposition
+        # Construct temporary for cycle decomposition
         σ = Permutation(v, check)
         cycles = cycle_decomposition(σ)
 
@@ -72,7 +72,7 @@ struct CyclePermutation <: AbstractPermutation
         if check
             σ_cat = Int[]
             for c ∈ cycles
-                σ_cat = vcat(σ_cat, c)
+                append!(σ_cat, c)
             end
             @assert allunique(σ_cat) "σ is not a decomposition in disjoint cycles"
         end
@@ -100,8 +100,8 @@ function degree(σ::CyclePermutation)
     # and again take the maximum over these cycles for the degree.
     deg = 1
     for c ∈ σ.cycles
-        if max(c...) > deg
-            deg = max(c...)
+        if maximum(c) > deg
+            deg = maximum(c)
         end
     end
     return deg
@@ -111,7 +111,7 @@ end
 # the sense that the operation becomes trivial (the decomposition is
 # already part of the object). This avoids redundant computations when
 # serializing the permutation (`Base.show()`).
-function cycle_decomposition(σ::CyclePermutation)
+function AbstractPermutations.cycle_decomposition(σ::CyclePermutation)
     return σ.cycles
 end
 
@@ -237,7 +237,7 @@ function Meta.parse(::Type{Permutation}, str::AbstractString)
 end
 
 function cycle_to_images(cycle::Vector{Int})
-    deg = max(cycle...)
+    deg = maximum(cycle)
     images = collect(1:deg)
 
     for k in range(1, length(cycle))
@@ -253,7 +253,7 @@ end
 export cycle_to_images
 
 macro perm_str(str)
-    return eval(Meta.parse(Permutation, str))
+    return Meta.parse(Permutation, str)
 end
 export @perm_str
 

--- a/src/permutations_02.jl
+++ b/src/permutations_02.jl
@@ -1,0 +1,85 @@
+export CyclePermutation2, degree, cycle_decomposition
+
+""" Implementation of `CyclePermutation` which does not assume knowledge
+of `Permutation`, and stores data exclusively in `cycles`.
+"""
+struct CyclePermutation2 <: AbstractPermutation
+    # Store the cyclic decomposition of the permutation
+    cycles::Vector{Vector{Int}}
+
+    function CyclePermutation2(v::AbstractVector{<:Integer}, check=true)
+        cycles = AbstractPermutations.cycle_decomposition(v, check)
+        # Check that we have a product of disjoint cycles.
+        if check
+            σ_cat = Int[]
+            for c ∈ cycles
+                append!(σ_cat, c)
+            end
+            @assert allunique(σ_cat) "σ is not a decomposition in disjoint cycles"
+        end
+        new(cycles) # inner constructor method
+    end
+end
+
+function degree(σ::CyclePermutation2)
+    # Cycles of length k>=2 have no elements mapped to themselves;
+    # it then suffices to take the maximum element in each cycle,
+    # and again take the maximum over these cycles for the degree.
+    deg = 1
+    non_trivial_cycles = filter(c->length(c)>=2, σ.cycles)
+    if length(σ.cycles) >= 1
+        deg = mapreduce(maximum, max, non_trivial_cycles; init=deg)
+    end
+    return deg
+end
+
+# Taken from https://github.com/kalmarek/CGT_UniHeidelberg_2022/pull/2/files#r862717462
+function (σ::CyclePermutation2)(n::Integer)
+    n > degree(σ) && return convert(Int, n)
+    for cycle in σ.cycles
+        idx = findfirst(==(n), cycle)
+        isnothing(idx) && continue
+        next_idx = ifelse(idx < length(cycle), idx+1, 1)
+        return cycle[next_idx]
+    end
+    return convert(Int, n) # e.g. when we decide later not to store cycles of length 1
+end
+
+# optional
+function AbstractPermutations.cycle_decomposition(σ::CyclePermutation2)
+    return σ.cycles
+end
+
+# Ad-hoc implementation of cycle_decomposition() for vectors which
+# follows indices until a cycle is encountered.
+function AbstractPermutations.cycle_decomposition(images::AbstractVector{<:Integer}, check=true)
+    # Include the check here because we are operating directly on a
+    # vector of images, instead of a permutation.
+    if check
+        @assert sort(images) == 1:length(images) "Image vector doesn't define a permutation"
+    end
+    n = length(images)
+    visited = falses(n)
+    cycles = []
+
+    for i ∈ 1:n # loop over the indices (permutation domain)
+        if visited[i]
+            continue
+        end
+        i_cycle, cycle = i, Int[]
+        visited[i_cycle] = true
+        push!(cycle, i_cycle)
+
+        for _ ∈ 2:n # no cycle can be longer than n
+            if images[i_cycle] == i
+                break
+            end            
+            i_cycle = images[i_cycle]
+            visited[i_cycle] = true
+            push!(cycle, i_cycle)
+        end
+        push!(cycles, copy(cycle))
+    end
+    return cycles
+end
+

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -24,3 +24,33 @@
     @test sprint(show, ρ) == "(1,2,3,4)"
     @test sprint(show, ρ*ρ) == "(1,3)(2,4)"
 end
+
+# TODO: The only change here is the type, could the testset be templatized?
+# (cf. TEMPLATE_TEST_CASE in Catch2)
+@testset "CyclePermutations" begin
+    import CGT_UniHeidelberg_2022: CyclePermutation, degree, orbit_plain
+
+    σ = CyclePermutation([2,1,3])
+    τ = CyclePermutation([1,3,2])
+
+    @test inv(one(σ)) == one(σ)
+    @test inv(σ)*σ == one(σ)
+    @test τ*inv(τ) == one(τ)
+    @test inv(σ*τ) == inv(τ)*inv(σ)
+    # (1,2)·(2,3) == (1,3,2)
+    @test σ*τ == CyclePermutation([3,1,2])
+
+    @test degree(σ) == 2
+    @test degree(τ) == 3
+    @test degree(one(σ)) == 1
+
+    @test orbit_plain(1, [CyclePermutation([2,3,4,1])]) == [1,2,3,4]
+
+    @test sprint(show, σ) == "(1,2)"
+    @test sprint(show, τ) == "(2,3)"
+    @test sprint(show, one(σ)) == "()"
+    ρ = CyclePermutation([2,3,4,1])
+    @test sprint(show, ρ) == "(1,2,3,4)"
+    @test sprint(show, ρ*ρ) == "(1,3)(2,4)"
+end
+

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -1,55 +1,26 @@
-@testset "Permutations" begin
+@testset "Permutations" for P in [Permutation, CyclePermutation]
     import CGT_UniHeidelberg_2022: Permutation, degree, orbit_plain
 
-    σ = Permutation([2,1,3])
-    τ = Permutation([1,3,2])
+    σ = P([2,1,3])
+    τ = P([1,3,2])
 
     @test inv(one(σ)) == one(σ)
     @test inv(σ)*σ == one(σ)
     @test τ*inv(τ) == one(τ)
     @test inv(σ*τ) == inv(τ)*inv(σ)
     # (1,2)·(2,3) == (1,3,2)
-    @test σ*τ == Permutation([3,1,2])
+    @test σ*τ == P([3,1,2])
 
     @test degree(σ) == 2
     @test degree(τ) == 3
     @test degree(one(σ)) == 1
 
-    @test orbit_plain(1, [Permutation([2,3,4,1])]) == [1,2,3,4]
+    @test orbit_plain(1, [P([2,3,4,1])]) == [1,2,3,4]
 
     @test sprint(show, σ) == "(1,2)"
     @test sprint(show, τ) == "(2,3)"
     @test sprint(show, one(σ)) == "()"
-    ρ = Permutation([2,3,4,1])
-    @test sprint(show, ρ) == "(1,2,3,4)"
-    @test sprint(show, ρ*ρ) == "(1,3)(2,4)"
-end
-
-# TODO: The only change here is the type, could the testset be templatized?
-# (cf. TEMPLATE_TEST_CASE in Catch2)
-@testset "CyclePermutations" begin
-    import CGT_UniHeidelberg_2022: CyclePermutation, degree, orbit_plain
-
-    σ = CyclePermutation([2,1,3])
-    τ = CyclePermutation([1,3,2])
-
-    @test inv(one(σ)) == one(σ)
-    @test inv(σ)*σ == one(σ)
-    @test τ*inv(τ) == one(τ)
-    @test inv(σ*τ) == inv(τ)*inv(σ)
-    # (1,2)·(2,3) == (1,3,2)
-    @test σ*τ == CyclePermutation([3,1,2])
-
-    @test degree(σ) == 2
-    @test degree(τ) == 3
-    @test degree(one(σ)) == 1
-
-    @test orbit_plain(1, [CyclePermutation([2,3,4,1])]) == [1,2,3,4]
-
-    @test sprint(show, σ) == "(1,2)"
-    @test sprint(show, τ) == "(2,3)"
-    @test sprint(show, one(σ)) == "()"
-    ρ = CyclePermutation([2,3,4,1])
+    ρ = P([2,3,4,1])
     @test sprint(show, ρ) == "(1,2,3,4)"
     @test sprint(show, ρ*ρ) == "(1,3)(2,4)"
 end
@@ -70,14 +41,12 @@ end
     @test Permutation([4,1,2,3]) == perm"(1,2)(2,3)(3,4)"
 
     # Invalid input
-    # XXX: test_throws doesn't seem to do anything. All I get is "Got
-    # exception outside of a @test".
-    # @test_throws Meta.ParseError perm"(1,)"
-    # @test_throws Meta.ParseError perm"(,2)"
-    # @test_throws Meta.ParseError perm"()"
-    # @test_throws Meta.ParseError perm"(1,2"
-    # @test_throws Meta.ParseError perm"2,1)"
-    # @test_throws Meta.ParseError perm"2"
-    # @test_throws Meta.ParseError perm"2;1"
-    # @test_throws Meta.ParseError perm"(2,3,1)⋅(4,5)" # this or (2,3,1)∗(4,5) is arguably also a valid case
+    @test_throws Meta.ParseError string_to_cycles("(1,)")
+    @test_throws Meta.ParseError string_to_cycles("(,2)")
+    @test_throws Meta.ParseError string_to_cycles("()")
+    @test_throws Meta.ParseError string_to_cycles("(1,2")
+    @test_throws Meta.ParseError string_to_cycles("2,1)")
+    @test_throws Meta.ParseError string_to_cycles("2")
+    @test_throws Meta.ParseError string_to_cycles("2;1")
+    @test_throws Meta.ParseError string_to_cycles("(2,3,1)⋅(4,5)") # this or (2,3,1)∗(4,5) is arguably also a valid case
 end

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -55,27 +55,29 @@ end
 end
 
 @testset "Permutations (deserialization)" begin
-    import CGT_UniHeidelberg_2022: Permutation
+    import CGT_UniHeidelberg_2022: Permutation, @perm_str
 
     # Identity
     @test Permutation(Int[]) == perm"(1)"
+    @test Permutation(Int[]) == perm"" # whether this should parse the identity or return an error is up for interpretation
 
     # Transpositions
-    @test Permutation([1,2]) == perm"(1,2)"
-    @test Permutation([1,3,2]) == perm"(1,2)(2,3)"
+    @test Permutation([2,1]) == perm"(1,2)"
+    @test Permutation([3,1,2]) == perm"(1,2)(2,3)"
 
-    # Cycles k>=3
+    # Other cycles
     @test Permutation([2,3,1,5,4]) == perm"(2,3,1)(4,5)"
-    # TODO: add some uneven permutations
+    @test Permutation([4,1,2,3]) == perm"(1,2)(2,3)(3,4)"
 
     # Invalid input
-    @test_throws Meta.ParseError perm"(1,)"
-    @test_throws Meta.ParseError perm"(,2)"
-    @test_throws Meta.ParseError perm"" # whether this should parse the identity or return an error is up for interpretation
-    @test_throws Meta.ParseError perm"()"
-    @test_throws Meta.ParseError perm"(1,2"
-    @test_throws Meta.ParseError perm"2,1)"
-    @test_throws Meta.ParseError perm"2"
-    @test_throws Meta.ParseError perm"2;1"
-    @test_throws Meta.ParseError perm"(2,3,1)⋅(4,5)" # this or (2,3,1)∗(4,5) is arguably also a valid case
+    # XXX: test_throws doesn't seem to do anything. All I get is "Got
+    # exception outside of a @test".
+    # @test_throws Meta.ParseError perm"(1,)"
+    # @test_throws Meta.ParseError perm"(,2)"
+    # @test_throws Meta.ParseError perm"()"
+    # @test_throws Meta.ParseError perm"(1,2"
+    # @test_throws Meta.ParseError perm"2,1)"
+    # @test_throws Meta.ParseError perm"2"
+    # @test_throws Meta.ParseError perm"2;1"
+    # @test_throws Meta.ParseError perm"(2,3,1)⋅(4,5)" # this or (2,3,1)∗(4,5) is arguably also a valid case
 end

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -54,3 +54,28 @@ end
     @test sprint(show, ρ*ρ) == "(1,3)(2,4)"
 end
 
+@testset "Permutations (deserialization)" begin
+    import CGT_UniHeidelberg_2022: Permutation
+
+    # Identity
+    @test Permutation(Int[]) == perm"(1)"
+
+    # Transpositions
+    @test Permutation([1,2]) == perm"(1,2)"
+    @test Permutation([1,3,2]) == perm"(1,2)(2,3)"
+
+    # Cycles k>=3
+    @test Permutation([2,3,1,5,4]) == perm"(2,3,1)(4,5)"
+    # TODO: add some uneven permutations
+
+    # Invalid input
+    @test_throws Meta.ParseError perm"(1,)"
+    @test_throws Meta.ParseError perm"(,2)"
+    @test_throws Meta.ParseError perm"" # whether this should parse the identity or return an error is up for interpretation
+    @test_throws Meta.ParseError perm"()"
+    @test_throws Meta.ParseError perm"(1,2"
+    @test_throws Meta.ParseError perm"2,1)"
+    @test_throws Meta.ParseError perm"2"
+    @test_throws Meta.ParseError perm"2;1"
+    @test_throws Meta.ParseError perm"(2,3,1)⋅(4,5)" # this or (2,3,1)∗(4,5) is arguably also a valid case
+end

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -1,4 +1,4 @@
-@testset "Permutations" for P in [Permutation, CyclePermutation]
+@testset "Permutations" for P in [Permutation, CyclePermutation, CyclePermutation2]
     import CGT_UniHeidelberg_2022: Permutation, degree, orbit_plain
 
     σ = P([2,1,3])


### PR DESCRIPTION
This PR implements #1, ii.e. the `Permutation` and `CyclePermutation` classes as implementation of `AbstractPermutation`. 

`Permutation` is as in the lecture. I chose the implementation for `CyclePermutation` as follows:

**Constructor**
* `CyclePermutation` stores both the cycles (from `cycle_decomposition()`) and the images (from the constructor argument). This is done so that `σ(i)` is done as an array read with `O(1)` complexity, instead of having to find the cycle which contains the index `i` (which I believe is `O(n)` because cycles are not necessarily sorted).
* When decomposing a permutation into cycles, the cycles are not necessarily disjoint. That said, I believe `cycle_decomposition()` does return disjoint cycles, by computing group orbits (which are either disjoint or identical) and a `visible` mask. I've encoded this assumption in an additional class invariant, which is verified if `check=true`.

**Operations**
* The implementation of `(σ::CyclePermutation)(i)` matches the one of `(σ::Permutation)(i)`, because `CyclePermutation` stores the cycles and images by the above.
  - **Q**: `CyclePermutation` is not a subtype of `Permutation`, so I assume something like `(σ::CyclePermutation)(i) = (σ::Permutation)(i)` is not possible. If so (and the function body were complex enough to make this worthwhile), a "detail" function could be created that's called by both `(σ::CyclePermutation)(i)` and `(σ::CyclePermutation)(i)`.
* `degree` is implemented by finding the highest index for each cycle, then taking the maximum over those. This should also work with the identity (`deg = 1` in the beginning) and cycles of length 1.
* `cycle_decomposition` is defined for any `AbstractPermutation`. However, in the case of a `CyclePermutation` the computations would be redundant, since a cycle decomposition is already known (and is stored in the object). Therefore I've added a specialization that returns `σ.cycles`.

Exercise 2 is still a work-in-progress. I've looked at `Expr`, `Symbol`, `Meta.parse` and written some tests for a later `perm"..."` implementation.

----
There is one outstanding issue I have with Exercise 1: I can't figure out how to actually run the code! When running the tests as described in issue #1, or through `julia --project=$PWD test/runtests.jl`, I get a long stacktrace:
```julia
Test Summary: |
CGT           | No tests
ERROR: LoadError: MethodError: no method matching degree(::Permutation)
Stacktrace:
  [1] cycle_decomposition(σ::Permutation)
    @ CGT_UniHeidelberg_2022.AbstractPermutations ~/source/repos/CGT_UniHeidelberg_2022/src/AbstractPermutations.jl:92
  [2] show(io::IOContext{IOBuffer}, σ::Permutation)
    @ CGT_UniHeidelberg_2022.AbstractPermutations ~/source/repos/CGT_UniHeidelberg_2022/src/AbstractPermutations.jl:76
  [3] show_delim_array(io::IOContext{IOBuffer}, itr::Tuple{Permutation}, op::Char, delim::Char, cl::Char, delim_one::Bool, i1::Int64, n::Int64)
    @ Base ./show.jl:1244
  [4] show_delim_array
    @ ./show.jl:1229 [inlined]
  [5] show(io::IOContext{IOBuffer}, t::Tuple{Permutation})
    @ Base ./show.jl:1262
  [6] _show_default(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:413
  [7] show_default
    @ ./show.jl:396 [inlined]
  [8] show(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:391
  [9] _show_default(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:413
 [10] show_default
    @ ./show.jl:396 [inlined]
 [11] show(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:391
 [12] sprint(f::Function, args::LoadError; context::Pair{Symbol, Bool}, sizehint::Int64)
    @ Base ./strings/io.jl:112
 [13] Test.Error(test_type::Any, orig_expr::Any, value::Any, bt::Any, source::Any)
    @ Test ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:174
 [14] macro expansion
    @ ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:1289 [inlined]
 [15] top-level scope
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/runtests.jl:5
in expression starting at /home/fvanmaele/source/repos/CGT_UniHeidelberg_2022/test/runtests.jl:4

caused by: LoadError: MethodError: no method matching degree(::Permutation)
Stacktrace:
  [1] cycle_decomposition(σ::Permutation)
    @ CGT_UniHeidelberg_2022.AbstractPermutations ~/source/repos/CGT_UniHeidelberg_2022/src/AbstractPermutations.jl:92
  [2] show(io::IOContext{IOBuffer}, σ::Permutation)
    @ CGT_UniHeidelberg_2022.AbstractPermutations ~/source/repos/CGT_UniHeidelberg_2022/src/AbstractPermutations.jl:76
  [3] show_delim_array(io::IOContext{IOBuffer}, itr::Tuple{Permutation}, op::Char, delim::Char, cl::Char, delim_one::Bool, i1::Int64, n::Int64)
    @ Base ./show.jl:1244
  [4] show_delim_array
    @ ./show.jl:1229 [inlined]
  [5] show(io::IOContext{IOBuffer}, t::Tuple{Permutation})
    @ Base ./show.jl:1262
  [6] _show_default(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:413
  [7] show_default
    @ ./show.jl:396 [inlined]
  [8] show(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:391
  [9] sprint(f::Function, args::MethodError; context::Pair{Symbol, Bool}, sizehint::Int64)
    @ Base ./strings/io.jl:112
 [10] Test.Error(test_type::Any, orig_expr::Any, value::Any, bt::Any, source::Any)
    @ Test ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:174
 [11] macro expansion
    @ ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:1289 [inlined]
 [12] top-level scope
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/permutations.jl:2
 [13] include(fname::String)
    @ Base.MainInclude ./client.jl:451
 [14] macro expansion
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/runtests.jl:5 [inlined]
 [15] macro expansion
    @ ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:1283 [inlined]
 [16] top-level scope
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/runtests.jl:5
in expression starting at /home/fvanmaele/source/repos/CGT_UniHeidelberg_2022/test/permutations.jl:1

caused by: MethodError: no method matching degree(::Permutation)
Stacktrace:
  [1] cycle_decomposition(σ::Permutation)
    @ CGT_UniHeidelberg_2022.AbstractPermutations ~/source/repos/CGT_UniHeidelberg_2022/src/AbstractPermutations.jl:92
  [2] show(io::IOContext{IOBuffer}, σ::Permutation)
    @ CGT_UniHeidelberg_2022.AbstractPermutations ~/source/repos/CGT_UniHeidelberg_2022/src/AbstractPermutations.jl:76
  [3] show_delim_array(io::IOContext{IOBuffer}, itr::Tuple{Permutation}, op::Char, delim::Char, cl::Char, delim_one::Bool, i1::Int64, n::Int64)
    @ Base ./show.jl:1244
  [4] show_delim_array
    @ ./show.jl:1229 [inlined]
  [5] show(io::IOContext{IOBuffer}, t::Tuple{Permutation})
    @ Base ./show.jl:1262
  [6] _show_default(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:413
  [7] show_default
    @ ./show.jl:396 [inlined]
  [8] show(io::IOContext{IOBuffer}, x::Any)
    @ Base ./show.jl:391
  [9] sprint(f::Function, args::MethodError; context::Pair{Symbol, Bool}, sizehint::Int64)
    @ Base ./strings/io.jl:112
 [10] Test.Error(test_type::Any, orig_expr::Any, value::Any, bt::Any, source::Any)
    @ Test ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:174
 [11] do_test(result::Test.ExecutionResult, orig_expr::Any)
    @ Test ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:634
 [12] macro expansion
    @ ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:445 [inlined]
 [13] macro expansion
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/permutations.jl:7 [inlined]
 [14] macro expansion
    @ ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:1283 [inlined]
 [15] top-level scope
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/permutations.jl:2
 [16] include(fname::String)
    @ Base.MainInclude ./client.jl:451
 [17] macro expansion
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/runtests.jl:5 [inlined]
 [18] macro expansion
    @ ~/packages/julias/julia-1.7/share/julia/stdlib/v1.7/Test/src/Test.jl:1283 [inlined]
 [19] top-level scope
    @ ~/source/repos/CGT_UniHeidelberg_2022/test/runtests.jl:5
```
which doesn't make sense to me since I've defined `degree(::Permutation)` and even marked it for exporting. What am I doing wrong?