### PR TITLE
`transversal`, `schreier` and `representative`

### DIFF
--- a/src/AbstractOrbits.jl
+++ b/src/AbstractOrbits.jl
@@ -5,34 +5,42 @@ import ..GroupElement
 export AbstractOrbit, Orbit, Transversal, Schreier
 
 """
-    `orbit_plain`, `transversal` and `schreier` have the common property
-    that we iterate over a vector of values δ (initialized with a
-    starting value) and a vector of generators `s` (of type
-    `GroupElement`). Then, we apply `action(δ, s)` and get some γ in the
-    orbit. This element is then processed exactly once, checking for
-    uniqueness.
+`orbit_plain`, `transversal` and `schreier` have the common property
+that we iterate over a vector of values δ (initialized with a starting
+value) and a vector of generators `s` (of type `GroupElement`). Then, we
+apply `action(δ, s)` and get some γ in the orbit. This element is then
+processed exactly once, checking for uniqueness.
 
-    Compared to `orbit_plain`, `transversal` and `schreier` proceed in
-    the same way but store some extra fields (namely, a `Dict`). As
-    such, the implementation here is based on this common denominator,
-    but allows to store and modify additional fields.
+Compared to `orbit_plain`, `transversal` and `schreier` proceed in the
+same way but store some extra fields (namely, a `Dict`). As such, the
+implementation here is based on this common denominator, but allows to
+store and modify additional fields.
 
-    There is one striking difference: `orbit_plain` is defined on a
-    vector of elements, and returns a union of orbits in this case.
-    `transversal` and `schreier` are only defined on a single element.
-    In this module we assume the orbit of a single element.
+There is one striking difference: `orbit_plain` is defined on a vector
+of elements, and returns a union of orbits in this case.  `transversal`
+and `schreier` are only defined on a single element.  In this module we
+assume the orbit of a single element.
 
-    The implementation is done by passing functions and their source
-    (dictionaries) to a generalized orbit function.
+Summarized, the interface can be defined as follows:
+
+1. `AbstractOrbit` can be constructed from an element x, a (non-empty)
+   set of generators S, and a group action (defaulting to ^).
+2. `AbstractOrbit` contains a vector Δ representing the orbit of x
+   under the group action, with unique elements.
 """
 abstract type AbstractOrbit end
 
-function orbit_producer(x, S::AbstractVector{<:GroupElement}, Vin::Dict, Vfunc, action=^)
+"""
+Generalized orbit function which takes an input dictionary `Vin` and a
+function f(δ,s,γ) to populate it. This is used in `Transversal` and
+`Schreier`, and these structures only define `Vin` and f accordingly.
+"""
+function orbit_producer(x::AbstractVector, S::AbstractVector{<:GroupElement}, Vin::Dict, Vfunc, action=^)
     @assert !isempty(S)
 
     # We iterate over both a set and an array because sets are
     # implicitly sorted on insertion, while arrays preserve order.
-    Δ_vec = [x]
+    Δ_vec = x
     Δ = Set(Δ_vec)
 
     for δ ∈ Δ_vec
@@ -43,7 +51,8 @@ function orbit_producer(x, S::AbstractVector{<:GroupElement}, Vin::Dict, Vfunc, 
                 # can continue over the whole orbit.
                 push!(Δ, γ)
                 push!(Δ_vec, γ)
-                # Perform additional operations on δ,s,γ
+                # Perform additional operations on δ,s,γ and Vin
+                # dictionary, typically Vin[γ] = f(δ, s)
                 Vfunc(Vin, δ, s, γ)
             end
         end
@@ -56,13 +65,16 @@ end
 struct Orbit <: AbstractOrbit
     Δ::AbstractVector
 
-    function Orbit(x, S::AbstractVector{<:GroupElement}, action=^)
+    # `Orbit` can be defined on an array of points, returning a union
+    # of orbits for each point.
+    function Orbit(x::AbstractVector, S::AbstractVector{<:GroupElement}, action=^)
         Δ_tmp = Dict{}()
         Δ_fnc = (Vin, δ, s, γ) -> nothing
 
-        return new(orbit_producer(x, S, Δ_tmp, Δ_fnc, action))
+        return new(orbit_producer(x, S, Δ_tmp, Δ_fnc, action))        
     end
 
+    Orbit(x, S::AbstractVector{<:GroupElement}, action=^) = Orbit([x], S, action)
     Orbit(x, s::GroupElement, action=^) = Orbit(x, [s], action)
 end
 
@@ -73,7 +85,7 @@ struct Transversal <: AbstractOrbit
     function Transversal(x, S::AbstractVector{<:GroupElement}, action=^)
         T_tmp = Dict(x => one(first(S)))
         T_fnc = (T_tmp, δ, s, γ) -> (T_tmp[γ] = T_tmp[δ]*s)
-        Δ_tmp = orbit_producer(x, S, T_tmp, T_fnc, action)
+        Δ_tmp = orbit_producer([x], S, T_tmp, T_fnc, action)
 
         return new(Δ_tmp, T_tmp)
     end
@@ -88,7 +100,7 @@ struct Schreier <: AbstractOrbit
     function Schreier(x, S::AbstractVector{<:GroupElement}, action=^)
         Sch_tmp = Dict{typeof(x), eltype(S)}()
         Sch_fnc = (Sch_tmp, δ, s, γ) -> (Sch_tmp[γ] = s)
-        Δ_tmp = orbit_producer(x, S, Sch_tmp, Sch_fnc, action)
+        Δ_tmp = orbit_producer([x], S, Sch_tmp, Sch_fnc, action)
 
         return new(Δ_tmp, Sch_tmp)
     end

--- a/src/AbstractOrbits.jl
+++ b/src/AbstractOrbits.jl
@@ -12,9 +12,11 @@ apply `action(δ, s)` and get some γ in the orbit. This element is then
 processed exactly once, checking for uniqueness.
 
 Compared to `orbit_plain`, `transversal` and `schreier` proceed in the
-same way but store some extra fields (namely, a `Dict`). As such, the
-implementation here is based on this common denominator, but allows to
-store and modify additional fields.
+same way but store some extra information (namely, a `Dict` representing
+a transversal or Schreier tree). In the case of `orbit_plain`, we also
+use a `Set` for fast element access. Since this is also a `Dict` (with
+`nothing` values), we can assume an `AbstractOrbit` includes both a
+vector and a dictionary.
 
 There is one striking difference: `orbit_plain` is defined on a vector
 of elements, and returns a union of orbits in this case.  `transversal`
@@ -27,49 +29,30 @@ Summarized, the interface can be defined as follows:
    set of generators S, and a group action (defaulting to ^).
 2. `AbstractOrbit` contains a vector Δ representing the orbit of x
    under the group action, with unique elements.
+3. `AbstractOrbit` contains a dictionary T with keys the orbit of x
+   under the group action.
 """
 abstract type AbstractOrbit end
 
 """
-Generalized orbit function which takes an input dictionary `Vin` and a
-function f(δ,s,γ) to populate it. This is used in `Transversal` and
-`Schreier`, and these structures only define `Vin` and f accordingly.
-
-The orbit Δ is taken an input argument so that both the orbit and the
-dictionary V can be initialized in the same place (the caller), reducing
-the odds of inconsistencies.
+Operations which are implemented using the `AbstractOrbit` interface.
 """
-function orbit_producer(Δ::AbstractVector, S::AbstractVector{<:GroupElement},
-                        V::Dict, Vfunc, action=^)
-    @assert !isempty(S)
-    for δ ∈ Δ
-        for s ∈ S
-            γ = action(δ, s)
-            if γ ∉ keys(V)
-                push!(Δ, γ)
-                push!(V, γ => Vfunc(V, δ, s))
-            end
-        end
-    end
-    return # Δ, V
-end
+Base.first(O::AbstractOrbit) = first(O.Δ)
+Base.haskey(O::AbstractOrbit) = haskey(O.T)
 
 struct Orbit <: AbstractOrbit
     Δ::AbstractVector
+    T::Dict
 
     function Orbit(x::AbstractVector, S::AbstractVector{<:GroupElement}, action=^)
         Δ_vec = x
-        Δ_set = Dict{eltype(x), Nothing}() # ad-hoc Set
-        noop = (V_tmp, δ, s) -> nothing
-
+        noop = (_, _, _) -> nothing
         # `Orbit` can be defined on an array of points, returning a union of
         # orbits for each point. Create a dictionary entry for each point.
-        for δ ∈ Δ_vec
-            push!(Δ_set, δ => nothing)
-        end
+        Δ_set = Dict(δ => noop(nothing, δ, nothing) for δ in Δ_vec)
 
-        orbit_producer(Δ_vec, S, Δ_set, noop, action) # populates Δ_vec, Δ_set
-        return new(Δ_vec)
+        _orbit_producer!(Δ_vec, S, Δ_set, noop, action)
+        return new(Δ_vec, Δ_set)
     end
 
     Orbit(x, S::AbstractVector{<:GroupElement}, action=^) = Orbit([x], S, action)
@@ -81,11 +64,7 @@ struct Transversal <: AbstractOrbit
     T::Dict # Dict{typeof(x), eltype(S)}()
 
     function Transversal(x, S::AbstractVector{<:GroupElement}, action=^)
-        Δ_vec = [x]
-        T_tmp = Dict(x => one(first(S)))
-        T_fnc = (T_tmp, δ, s) -> T_tmp[δ]*s
-
-        orbit_producer(Δ_vec, S, T_tmp, T_fnc, action) # populates Δ, T
+        Δ_vec, T_tmp = transversal(x, S, action)
         return new(Δ_vec, T_tmp)
     end
 
@@ -94,15 +73,11 @@ end
 
 struct Schreier <: AbstractOrbit
     Δ::AbstractVector
-    Sch::Dict # Dict{typeof(x), eltype(S)}()
+    T::Dict # Dict{typeof(x), eltype(S)}()
 
     function Schreier(x, S::AbstractVector{<:GroupElement}, action=^)
-        Δ_vec = [x]
-        Sch_tmp = Dict{typeof(x), eltype(S)}(x => one(first(S)))
-        Sch_fnc = (Sch_tmp, δ, s) -> s
-
-        orbit_producer(Δ_vec, S, Sch_tmp, Sch_fnc, action) # populates Δ, Sch
-        return new(Δ_vec, Sch_tmp)
+        Δ_vec, Sch = schreier(x, S, action)
+        return new(Δ_vec, Sch)
     end
 
     Schreier(x, s::GroupElement, action=^) = Schreier(x, [s], action)

--- a/src/AbstractOrbits.jl
+++ b/src/AbstractOrbits.jl
@@ -37,9 +37,6 @@ function f(δ,s,γ) to populate it. This is used in `Transversal` and
 """
 function orbit_producer(x::AbstractVector, S::AbstractVector{<:GroupElement}, Vin::Dict, Vfunc, action=^)
     @assert !isempty(S)
-
-    # We iterate over both a set and an array because sets are
-    # implicitly sorted on insertion, while arrays preserve order.
     Δ_vec = x
     Δ = Set(Δ_vec)
 

--- a/src/AbstractOrbits.jl
+++ b/src/AbstractOrbits.jl
@@ -31,6 +31,10 @@ abstract type AbstractOrbit end
 # `Transversal` and `Schreier` structs.
 function orbit_producer(x, S::AbstractVector{<:GroupElement}, action=^, Vin=nothing, Vfunc=nothing)
     @assert !isempty(S)
+    if isnothing(Vfunc)
+        Vfunc = (Vin, δ, s, γ) -> nothing
+    end
+
     # We iterate over both a set and an array because sets are
     # implicitly sorted on insertion, while arrays preserve order.
     Δ_vec = [x]
@@ -44,11 +48,8 @@ function orbit_producer(x, S::AbstractVector{<:GroupElement}, action=^, Vin=noth
                 # can continue over the whole orbit.
                 push!(Δ, γ)
                 push!(Δ_vec, γ)
-
-                # Perform additional operations on δ,s,γ
-                if !isnothing(Vfunc)
-                    Vfunc(Vin, δ, s, γ)
-                end
+                # Perform additional operations on δ,s,γ (if defined)
+                Vfunc(Vin, δ, s, γ)
             end
         end
     end

--- a/src/AbstractOrbits.jl
+++ b/src/AbstractOrbits.jl
@@ -1,0 +1,110 @@
+# module AbstractOrbits
+
+import ..GroupElement
+
+export AbstractOrbit, Orbit, Transversal, Schreier
+
+"""
+    `orbit_plain`, `transversal` and `schreier` have the common property
+    that we iterate over a vector of values δ (initialized with a
+    starting value) and a vector of generators `s` (of type
+    `GroupElement`). Then, we apply `action(δ, s)` and get some γ in the
+    orbit. This element is then processed exactly once, checking for
+    uniqueness.
+
+    Compared to `orbit_plain`, `transversal` and `schreier` proceed in
+    the same way but store some extra fields (namely, a `Dict`). As
+    such, the implementation here is based on this common denominator,
+    but allows to store and modify additional fields.
+
+    There is one striking difference: `orbit_plain` is defined on a
+    vector of elements, and returns a union of orbits in this case.
+    `transversal` and `schreier` are only defined on a single element.
+    In this module we assume the orbit of a single element.
+
+    The "common loop" between `orbit_plain`, `transversal` and `schreier`
+    can be implemented with some heavy machinery, i.e. coroutines. [1]
+
+    [1] https://docs.julialang.org/en/v1/manual/asynchronous-programming
+"""
+abstract type AbstractOrbit end
+
+# Parametrized producer which will be specialized later in `Orbit`,
+# `Transversal` and `Schreier` structs.
+function orbit_producer(c::Channel, x, S::AbstractVector{<:GroupElement}, action)
+    @assert !isempty(S)
+
+    # We iterate over both a set and an array because sets are
+    # implicitly sorted on insertion, while arrays preserve order.
+    Δ_vec = [x]
+    Δ = Set(Δ_vec)
+
+    for δ ∈ Δ_vec
+        for s ∈ S
+            γ = action(δ, s)
+            if γ ∉ Δ
+                # We push to arrays inside the function so that the loop
+                # can continue over the whole orbit.
+                push!(Δ, γ)
+                push!(Δ_vec, γ)
+                # The magic happens here!
+                put!(c, (δ, s, γ))
+            end
+        end
+    end
+end
+
+# Specialization for `orbit_plain`. This might result in an additional
+# copy of the orbit, as it is stored in both producer the consumer.
+struct Orbit <: AbstractOrbit
+    Δ::AbstractVector
+
+    function Orbit(x, S::AbstractVector{<:GroupElement}, action=^)
+        producer(c::Channel) = orbit_producer(c, x, S, action)
+        Δ_tmp = [x]
+
+        for vals in Channel(producer)
+            _, _, γ = vals # δ, s not needed
+            push!(Δ_tmp, γ)
+        end
+        return new(Δ_tmp)
+    end
+end
+
+struct Transversal <: AbstractOrbit
+    Δ::AbstractVector
+    T # Dict{typeof(x), eltype(S)}()
+
+    function Transversal(x, S::AbstractVector{<:GroupElement}, action=^)
+        producer(c::Channel) = orbit_producer(c, x, S, action)
+        Δ_tmp = [x]
+        T_tmp = Dict(x => one(first(S)))
+
+        for vals in Channel(producer)
+            δ, s, γ = vals
+            push!(Δ_tmp, γ)
+            T_tmp[γ] = T_tmp[δ]*s
+        end
+        return new(Δ_tmp, T_tmp)
+    end
+end
+
+struct Schreier <: AbstractOrbit
+    Δ::AbstractVector
+    Sch # Dict{typeof(x), Int64}()
+
+    function Schreier(x, S::AbstractVector{<:GroupElement}, action=^)
+        producer(c::Channel) = orbit_producer(c, x, S, action)
+        Δ_tmp = [x]
+        Sch_tmp = Dict{typeof(x), Int64}()
+
+        for vals in Channel(producer)
+            δ, s, γ = vals
+            push!(Δ_tmp, γ)
+            Sch_tmp[γ] = s
+        end
+        return new(Δ_tmp, Sch_tmp)
+    end
+end
+
+# end # of module AbstractOrbits

--- a/src/AbstractOrbits.jl
+++ b/src/AbstractOrbits.jl
@@ -62,6 +62,8 @@ struct Orbit <: AbstractOrbit
 
         return new(orbit_producer(x, S, Δ_tmp, Δ_fnc, action))
     end
+
+    Orbit(x, s::GroupElement, action=^) = Orbit(x, [s], action)
 end
 
 struct Transversal <: AbstractOrbit
@@ -75,6 +77,8 @@ struct Transversal <: AbstractOrbit
 
         return new(Δ_tmp, T_tmp)
     end
+
+    Transversal(x, s::GroupElement, action=^) = Transversal(x, [s], action)
 end
 
 struct Schreier <: AbstractOrbit
@@ -88,6 +92,8 @@ struct Schreier <: AbstractOrbit
 
         return new(Δ_tmp, Sch_tmp)
     end
+
+    Schreier(x, s::GroupElement, action=^) = Schreier(x, [s], action)
 end
 
 # end # of module AbstractOrbits

--- a/src/CGT_UniHeidelberg_2022.jl
+++ b/src/CGT_UniHeidelberg_2022.jl
@@ -10,4 +10,7 @@ include("permutations.jl")
 include("permutations_02.jl")
 include("transversals.jl")
 
+include("AbstractOrbits.jl")
+# using .AbstractOrbits
+
 end # of module CGT_UniHeidelberg_2022

--- a/src/CGT_UniHeidelberg_2022.jl
+++ b/src/CGT_UniHeidelberg_2022.jl
@@ -8,8 +8,8 @@ using .AbstractPermutations
 
 include("permutations.jl")
 include("permutations_02.jl")
-include("transversals.jl")
 
+include("transversals.jl")
 include("AbstractOrbits.jl")
 # using .AbstractOrbits
 

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -99,9 +99,8 @@ function degree(σ::CyclePermutation)
     # it then suffices to take the maximum element in each cycle,
     # and again take the maximum over these cycles for the degree.
     deg = 1
-    non_trivial_cycles = filter(c->length(c)>=2, σ.cycles)
     if length(σ.cycles) >= 1
-        deg = mapreduce(maximum, max, non_trivial_cycles; init=deg)
+        deg = mapreduce(maximum, max, σ.cycles; init=deg)
     end
     return deg
 end

--- a/src/permutations_02.jl
+++ b/src/permutations_02.jl
@@ -26,9 +26,8 @@ function degree(σ::CyclePermutation2)
     # it then suffices to take the maximum element in each cycle,
     # and again take the maximum over these cycles for the degree.
     deg = 1
-    non_trivial_cycles = filter(c->length(c)>=2, σ.cycles)
     if length(σ.cycles) >= 1
-        deg = mapreduce(maximum, max, non_trivial_cycles; init=deg)
+        deg = mapreduce(maximum, max, σ.cycles; init=deg)
     end
     return deg
 end
@@ -73,12 +72,20 @@ function AbstractPermutations.cycle_decomposition(images::AbstractVector{<:Integ
         for _ ∈ 2:n # no cycle can be longer than n
             if images[i_cycle] == i
                 break
-            end            
+            end
             i_cycle = images[i_cycle]
             visited[i_cycle] = true
             push!(cycle, i_cycle)
         end
-        push!(cycles, copy(cycle))
+
+        # Since we are looping over the length of the images, instead of
+        # over the degree, it is possible to have (several) cycles of
+        # length 1 (e.g. [1], [2], [3], ...). We could either accept
+        # that the identity has empty cycles, or only keep [1] as [2],
+        # ... are redundant.
+        if length(cycle) >= 2 || i == 1
+            push!(cycles, copy(cycle))
+        end
     end
     return cycles
 end

--- a/src/transversals.jl
+++ b/src/transversals.jl
@@ -123,9 +123,9 @@ function representative(y, Δ, Sch, action=^)
         # s sends some previous point on the orbit to the current one
         s = Sch[current_point]
         # shift current one to the previous one
-        current_point = current_point^inv(s)
+        current_point = action(current_point, inv(s))
         # accumulate the change
-        g = s * g
+        g = s*g
         # observe: g sends current_point to y.
     end
     return g

--- a/src/transversals.jl
+++ b/src/transversals.jl
@@ -73,11 +73,7 @@ function schreier(x, S::AbstractVector{<:GroupElement}, action=^)
     @assert !isempty(S)
     Δ_vec = [x]
     Δ = Set(Δ_vec)
-
-    # The generating set `S` could include the neutral element `e`, so 
-    # `S[Sch[γˢ]] == s` should also be defined in this case.
-    # To sidestep the issue, initialize `Sch` as an empty dictionary.
-    Sch = Dict{typeof(x), Int64}()
+    Sch = Dict{typeof(x), eltype(S)}()
 
     for δ in Δ_vec
         for s in S
@@ -105,17 +101,17 @@ Compute a representative `g` of left-coset `Stab_G(x)g` corresponding to point `
 * `g ∈ G` such that `xᵍ = y`.
 """
 function representative(y, Δ, Sch, action=^)
-    @assert !isempty(S)
     @assert !isempty(Δ)
     current_point = y
-    g = one(first(S))
+    # XXX: this only works if `Sch` is non-empty
+    g = one(first(values(Sch)))
 
     # If `y = xᵍ` for `g` in `Stab_G(x)`, then `schreier()` places `y`
     # in the orbit, but not in `Sch`. Therefore we cannot distinguish
     # from `Sch` alone if `y` is _not_ in the orbit, or merely the root
     # of the Schreier tree. To disambiguate, the element `x` can be
     # specified; the full orbit Δ is not required.
-    x = Δ[1]
+    x = first(Δ)
 
     # If `y` is not x, and not in the orbit, the function will terminate
     # with `KeyError`. To make this a bit more clear, add an assert.

--- a/src/transversals.jl
+++ b/src/transversals.jl
@@ -103,8 +103,7 @@ It is assumed that elements `G` act on `Ω` _on the right_ via `action(x, g)`.
  * `action` - function defining an action of `G`. Defaults to `^`.
 ### Output
  * `Δ::Vector` - the orbit of `x` under the action of `G`, as a `Vector`,
- * `Sch::Dict` - a Schreier tree. Only the generator indices are stored,
-   i.e. `S[Sch[γˢ] == s` holds for every `γ ∈ Δ` and every `s ∈ S`.
+ * `Sch::Dict` - a Schreier tree.
 """
 function schreier(x, S::AbstractVector{<:GroupElement}, action=^)
     @assert !isempty(S)
@@ -117,12 +116,12 @@ function schreier(x, S::AbstractVector{<:GroupElement}, action=^)
     Sch = Dict{typeof(x), Int64}()
 
     for δ in Δ_vec
-        for i in 1:length(S)
-            γ = action(δ, S[i])
+        for s in S
+            γ = action(δ, s)
             if γ ∉ Δ
                 push!(Δ, γ)
                 push!(Δ_vec, γ)
-                Sch[γ] = i
+                Sch[γ] = s
             end
         end
     end
@@ -161,7 +160,7 @@ function representative(y, Δ, Sch, action=^)
     end
 
     while current_point ≠ x
-	s = S[Sch[current_point]]            # s sends some previous point on the orbit to the current one
+	s = Sch[current_point]            # s sends some previous point on the orbit to the current one
 	current_point = current_point^inv(s) # shift current one to the previous one
 	g = s * g                            # accumulate the change
 	# observe: g sends current_point to y.

--- a/src/transversals.jl
+++ b/src/transversals.jl
@@ -160,10 +160,10 @@ function representative(y, Δ, Sch, action=^)
     end
 
     while current_point ≠ x
-	s = Sch[current_point]            # s sends some previous point on the orbit to the current one
-	current_point = current_point^inv(s) # shift current one to the previous one
-	g = s * g                            # accumulate the change
-	# observe: g sends current_point to y.
+        s = Sch[current_point]            # s sends some previous point on the orbit to the current one
+        current_point = current_point^inv(s) # shift current one to the previous one
+        g = s * g                            # accumulate the change
+        # observe: g sends current_point to y.
     end
     return g
 end

--- a/src/transversals.jl
+++ b/src/transversals.jl
@@ -20,8 +20,26 @@ It is assumed that elements `G` act on `Ω` _on the right_ via `action(x, g)`.
 """
 function transversal(x, S::AbstractVector{<:GroupElement}, action=^)
     @assert !isempty(S)
+    Δ_vec = [x]
+    Δ = Set(Δ_vec)
 
-    return
+    # The definition of the unit element uses that `S` is not empty, and
+    # that `one()` is defined for `GroupElement`.
+    e = one(first(S))
+    T = Dict{typeof(x), eltype(S)}()
+    T[x] = e
+
+    for δ in Δ_vec
+        for s in S
+            γ = action(δ, s)
+            if γ ∉ Δ
+                push!(Δ, γ)
+                push!(Δ_vec, γ)
+                T[γ] = T[δ]*s
+            end
+        end
+    end
+    return Δ_vec, T
 end
 
 """

--- a/src/transversals.jl
+++ b/src/transversals.jl
@@ -24,26 +24,20 @@ transversal(x, s::GroupElement, action=^) = transversal(x, [s], action)
 
 function transversal(x, S::AbstractVector{<:GroupElement}, action=^)
     @assert !isempty(S)
-    Δ_vec = [x]
-    Δ = Set(Δ_vec)
-
-    # The definition of the unit element uses that `S` is not empty, and
-    # that `one()` is defined for `GroupElement`.
-    e = one(first(S))
+    Δ = [x]
+    e = one(first(S)) # S not empty, `one` defined for `GroupElement`
     T = Dict(x => e)
-    # T = Dict{typeof(x), eltype(S)}(); T[x] = e
 
-    for δ in Δ_vec
+    for δ in Δ
         for s in S
             γ = action(δ, s)
-            if γ ∉ Δ
+            if γ ∉ keys(T)
                 push!(Δ, γ)
-                push!(Δ_vec, γ)
-                T[γ] = T[δ]*s
+                push!(T, γ => T[δ]*s)
             end
         end
     end
-    return Δ_vec, T
+    return Δ, T
 end
 
 """
@@ -71,21 +65,22 @@ schreier(x, s::GroupElement, action=^) = schreier(x, [s], action)
 
 function schreier(x, S::AbstractVector{<:GroupElement}, action=^)
     @assert !isempty(S)
-    Δ_vec = [x]
-    Δ = Set(Δ_vec)
-    Sch = Dict{typeof(x), eltype(S)}()
+    Δ = [x]
+    # XXX: Since we use the Sch dictionary to check elements in the
+    # orbit, we add `Sch[x] = e` so that `x` is not added a second time.
+    Sch = Dict(x => one(first(S)))
+    #Sch = Dict{typeof(x), eltype(S)}()
 
-    for δ in Δ_vec
+    for δ in Δ
         for s in S
             γ = action(δ, s)
-            if γ ∉ Δ
+            if γ ∉ keys(Sch)
                 push!(Δ, γ)
-                push!(Δ_vec, γ)
-                Sch[γ] = s
+                push!(Sch, γ => s)
             end
         end
     end
-    return Δ_vec, Sch
+    return Δ, Sch
 end
 
 """

--- a/test/transversals.jl
+++ b/test/transversals.jl
@@ -31,11 +31,42 @@ import CGT_UniHeidelberg_2022: transversal, schreier, representative, GroupEleme
     end
 
     @testset "factored transversal" begin
-        # implement here transversal_factored which contains list of generators instead of their product
+        """
+        This function stores factors of elements in the transversal, instead
+        of elements themselves. Whenever we ask for a coset representative,
+        this means we need to perform `length(T[γ])` multiplications to
+        recover it.
+
+        If we only want to store the indices of the generators, instead of
+        the generators themselves, `T[γ]` is an `Int[]` array, and we loop
+        over `1:length(S)` instead of `S` itself. The identity can then be
+        represented either be left out (by initializing `T` as an empty
+        dictionary), or a special value; in the former case, array
+        concatenation `T[γ] = [T[δ]; s]` will contain one element less.
+        """
+        transversal_factored(x, s::GroupElement, action=^) = transversal_factored(x, [s], action)
+
         function transversal_factored(x, S::AbstractVector{<:GroupElement}, action=^)
             @assert !isempty(S)
+            Δ_vec = [x]
+            Δ = Set(Δ_vec)
 
-            return
+            # The definition of the unit element uses that `S` is not
+            # empty, and that `one()` is defined for `GroupElement`.
+            e = one(first(S))
+            T = Dict(x => [e])
+
+            for δ in Δ_vec
+                for s in S
+                    γ = action(δ, s)
+                    if γ ∉ Δ
+                        push!(Δ, γ)
+                        push!(Δ_vec, γ)
+                        T[γ] = [T[δ]; s]
+                    end
+                end
+            end
+            return Δ_vec, T
         end
 
         @testset "action on points" begin


### PR DESCRIPTION
Took a few attempts but all the tests succeed now.

Regarding `AbstractOrbit`, I first used [Channels](https://docs.julialang.org/en/v1/manual/asynchronous-programming/#Communicating-with-Channels)) to isolate the bulk of the `orbit` loop. I then switched to function parameters for a simpler implementation.

Also included a commit for a `week-1` fix I forgot to push.