### PR TITLE
Schreier-Sims

### DIFF
--- a/src/orbits.jl
+++ b/src/orbits.jl
@@ -85,7 +85,8 @@ struct Transversal{T,GEl,Ac} <: AbstractTransversal{T,GEl}
             for s in S
                 y = action(pt, s)
                 y ∈ trans && continue
-                push!(trans, y=>trans[pt]*s)
+                #push!(trans, y=>trans[pt]*s)
+                push!(trans, pt, y=>s)
             end
         end
         return trans
@@ -107,12 +108,12 @@ function Base.getindex(t::Transversal, pt)
     return t.representatives[pt]
 end
 
-function Base.push!(t::Transversal, y_g::Pair{T, <:GroupElement}) where T
-    y, g = y_g
+function Base.push!(t::Transversal, pt, y_s::Pair{T, <:GroupElement}) where T
+    y, s = y_s
     if !(y in t)
         push!(t.points, y)
     end
-    t.representatives[y] = g
+    t.representatives[y] = t.representatives[pt]*s
     return t
 end
 Base.setindex!(t::Transversal, g::GroupElement, pt) = push!(t, pt=>g)
@@ -141,7 +142,7 @@ struct SchreierTree{T,GEl,Ac} <: AbstractTransversal{T,GEl}
                 # the new representative to be pushed. Uncommenting the line, however, results in
                 # a non-trivial factor for the distinguished element, and getindex does
                 y ∈ Sch && continue
-                push!(Sch, y=>s) # Push (reference to) group generator
+                push!(Sch, pt, y=>s) # Push (reference to) group generator
             end
         end
         return Sch
@@ -172,7 +173,7 @@ function Base.getindex(t::SchreierTree, pt)
 end
 
 # Note that we push generators here, instead of group elements.
-function Base.push!(t::SchreierTree, y_s::Pair{T, <:GroupElement}) where T
+function Base.push!(t::SchreierTree, pt, y_s::Pair{T, <:GroupElement}) where T
     y, s = y_s
     if !(y in t)
         push!(t.points, y)

--- a/src/schreier_sims.jl
+++ b/src/schreier_sims.jl
@@ -4,7 +4,7 @@ struct StabilizerChain{T<:AbstractTransversal, P<:AbstractPermutation}
 
     function StabilizerChain(
         transversals::AbstractVector{<:AbstractTransversal},
-        gens::AbstractVector{<:AbstractPermutation},
+        gens::AbstractVector{<:AbstractVector{<:AbstractPermutation}},
     )
         @assert length(transversals) == length(gens)
         T = eltype(transversals)
@@ -43,7 +43,7 @@ function sift(sc::StabilizerChain, g::AbstractPermutation; start_at_depth=1)
     for i in start_at_depth:depth(sc)
         T = transversal(sc, i)
         β = first(T)
-        γ = action(sc)(β, r)
+        γ = action(T)(β, r)
 
         if γ ∉ T
             return i, r
@@ -104,9 +104,10 @@ function extend_gens!(sc::StabilizerChain, g::AbstractPermutation; at_depth::Int
         γ = action(T)(δ, g)
         if γ ∉ T
             # add γ to orbit, update transversal
-            push!(T, γ=>T(δ)*g)
+            push!(T, δ, γ=>g)
         else
-            s = T(δ)*g*inv(T(γ)) # Schreier generator
+            # γ is a coset representative for G(i+1) in G(i)
+            s = T[δ]*g*inv(T[γ]) # Schreier generator
             push!(sc, s, at_depth=at_depth+1) # push to next layer
         end
     end
@@ -116,9 +117,9 @@ function extend_gens!(sc::StabilizerChain, g::AbstractPermutation; at_depth::Int
         for b ∈ sc.gens[at_depth] # includes g
             γ = action(T)(δ, b)
             if γ ∉ T
-                push!(T, γ=>T(δ)*b)
+                push!(T, δ, γ=>b)
             else
-                s = T(δ)*b*inv(T(γ))
+                s = T[δ]*b*inv(T[γ])
                 push!(sc, s, at_depth=at_depth+1)
             end
         end

--- a/src/schreier_sims.jl
+++ b/src/schreier_sims.jl
@@ -104,7 +104,7 @@ function extend_gens!(sc::StabilizerChain, g::AbstractPermutation; at_depth::Int
         γ = action(T)(δ, g)
         if γ ∉ T
             # add γ to orbit, update transversal
-            push!(T, γ)
+            push!(T, γ=>T(δ)*g)
         else
             s = T(δ)*g*inv(T(γ)) # Schreier generator
             push!(sc, s, at_depth=at_depth+1) # push to next layer
@@ -116,7 +116,7 @@ function extend_gens!(sc::StabilizerChain, g::AbstractPermutation; at_depth::Int
         for b ∈ sc.gens[at_depth] # includes g
             γ = action(T)(δ, b)
             if γ ∉ T
-                push!(T, γ)
+                push!(T, γ=>T(δ)*b)
             else
                 s = T(δ)*b*inv(T(γ))
                 push!(sc, s, at_depth=at_depth+1)

--- a/test/schreier_sims.jl
+++ b/test/schreier_sims.jl
@@ -5,16 +5,17 @@
 
     for group_order in 2:30
         for S in SmallPermGroups[group_order]
-            sc = CGT.schreier_sims(S) # defaults to Transversal
+            Trans_t = CGT.Transversal{Int, eltype(S), typeof(^)}
+            sc = CGT.schreier_sims(Trans_t, S)
             @test order(Int, sc) == group_order
         end
     end
 
-    # for group_order in 2:30
-    #     for S in SmallPermGroups[group_order]
-    #         STree_t = CGT.SchreierTree{Int, eltype(S), typeof(^)}
-    #         sc_tree = CGT.schreier_sims(STree_t, S)
-    #         @test order(Int, sc_tree) == group_order
-    #     end
-    # end
+    for group_order in 2:30
+        for S in SmallPermGroups[group_order]
+            STree_t = CGT.SchreierTree{Int, eltype(S), typeof(^)}
+            sc_tree = CGT.schreier_sims(STree_t, S)
+            @test order(Int, sc_tree) == group_order
+        end
+    end
 end


### PR DESCRIPTION
So far I've implemented `sift`, `extend_gens!` and `SchreierTree`. The tests, as-is, failed with:
```julia
    Testing Running tests...
Schreier-Sims algorithm: Error During Test at /home/fvanmaele/source/repos/CGT_UniHeidelberg_2022/test/schreier_sims.jl:1
  Got exception outside of a @test
  MethodError: no method matching CGT_UniHeidelberg_2022.StabilizerChain(::Vector{Transversal{Int64, Permutation, typeof(^)}}, ::Vector{Vector{Permutation}})
  Closest candidates are:
    CGT_UniHeidelberg_2022.StabilizerChain(::AbstractVector{<:CGT_UniHeidelberg_2022.AbstractTransversal}, ::AbstractVector{<:CGT_UniHeidelberg_2022.AbstractPermutations.AbstractPermutation}) at ~/source/repos/CGT_UniHeidelberg_2022/src/schreier_sims.jl:5
```
I guess this is because `schreier_sims` expects a single generating set, but `SmallPermGroups` defines sets of generating sets (where each defines a group of a given order). Changing the test to:
```julia
for group_order in 2:30
    for (i, _) in enumerate(SmallPermGroups[group_order])
        for S in SmallPermGroups[group_order][i]
            Trans_t = CGT.Transversal{Int, eltype(S), typeof(^)}
            sc = CGT.schreier_sims(Trans_t, S)
            @test order(Int, sc) == group_order
        end
    end
end
```
results in another error:
```julia
Schreier-Sims algorithm: Error During Test at /home/fvanmaele/source/repos/CGT_UniHeidelberg_2022/test/schreier_sims.jl:1
  Got exception outside of a @test
  TypeError: in AbstractTransversal, in GEl, expected GEl<:CGT_UniHeidelberg_2022.GroupElement, got Type{Any}
```
For the third part of the exercise, I thought on changing the interface for `Transversal` as follows:
```julia
function Base.push!(t::Transversal, pt, y_s::Pair{T, <:GroupElement}) where T
    y, s = y_s
    if !(y in t)
        push!(t.points, y)
    end
    t.representatives[y] = trans[pt]*s
    return t
end
Base.setindex!(t::Transversal, g::GroupElement, pt) = push!(t, pt=>g)
```
```
push!(trans, pt, y=>s)
```
with `pt` is ignored in the `SchreierTree` implementation:
```julia
function Base.push!(t::SchreierTree, pt, y_s::Pair{T, <:GroupElement}) where T
    y, s = y_s
    if !(y in t)
        push!(t.points, y)
    end
    t.factors[y] = s
    return t
end
```