### PR TITLE
add `Alphabet`, `Word`, `FreeGroup`

### DIFF
--- a/src/CGT_UniHeidelberg_2022.jl
+++ b/src/CGT_UniHeidelberg_2022.jl
@@ -16,5 +16,8 @@ using .AbstractPermutations
 include("permutations.jl")
 include("permutations_02.jl")
 include("schreier_sims.jl")
+include("alphabet.jl")
+include("word.jl")
+include("free_group.jl")
 
 end # of module CGT_UniHeidelberg_2022

--- a/src/alphabet.jl
+++ b/src/alphabet.jl
@@ -1,0 +1,105 @@
+# included from CGT_UniHeidelberg_2022.jl
+
+export Alphabet, hasinverse, setinverse!
+
+""" Allow arbitrary objects (except Integers) as letters
+Types:
+ * `T`: object representing a letter in the alphabet
+Indices are assumed to be of type Int64, the same as with Vector{T}.
+"""
+struct Alphabet{T}
+    gens::Vector{T}
+    gens_to_int::Dict{T, Int}  # maps objects T to integers
+    inv_state::Dict{T,T}       # maps objects T to formal inverses
+
+    function Alphabet{T}(S::AbstractVector) where T
+        # To distinguish between "indexing integers" and "indexing letters" we
+        # do not allow integers as element types.
+        @assert !(T <: Integer)
+
+        # The set may either contain redundant, or self-inverse generators. In
+        # this case, integer representations are not unique (with the last
+        # occurence defining the index).  To avoid this case, verify that the
+        # set of generators has no redundant elements.
+        @assert (length(unique(S)) == length(S))
+        A = new{T}(S, Dict{T,typeof(1)}(), Dict{T,T}())
+
+        # Map integers sequentially (starting at 1)
+        for i in 1:length(S)
+            push!(A.gens_to_int, S[i]=>i)
+        end
+        return A
+    end
+end
+
+# Loop methods
+Base.iterate(A::Alphabet) = iterate(A.gens)
+Base.iterate(A::Alphabet, state) = iterate(A.gens, state)
+Base.length(A::Alphabet) = length(A.gens)
+
+# O(1) element check
+Base.in(letter, A::Alphabet) = haskey(A.gens_to_int, letter)
+
+# Maps an index to a letter
+function Base.getindex(A::Alphabet, index::Integer)
+    @assert index >= 1 "alphabet indices start at 1"
+    @assert index <= length(A.gens) "alphabet is shorter than requested $index"
+    return A.gens[index]
+end
+
+# Maps a letter to an index
+function Base.getindex(A::Alphabet, letter)
+    @assert letter ∈ A "letter is not in alphabet"
+    return A.gens_to_int[letter]
+end
+
+function setinverse!(A::Alphabet{T}, x::T, X::T) where T
+    @assert x ∈ A "letter is not in alphabet"
+    @assert X ∈ A "letter is not in alphabet"
+    A.inv_state[x] = X
+    A.inv_state[X] = x
+end
+
+# Q: The exercise mentions when asking for an inverse, and the element is not
+# invertible, that an error should be returned. What would be the benefit in
+# this case over return a boolean? (An error is raised in the `inv` function)
+function hasinverse(A::Alphabet, letter)
+    @assert letter ∈ A "letter is not in alphabet"
+    return haskey(A.inv_state, letter)
+end
+
+function hasinverse(A::Alphabet, index::Integer)
+    return haskey(A.inv_state, A[index])
+end
+
+function Base.inv(A::Alphabet, letter)
+    if hasinverse(A, letter)
+        return A.inv_state[letter] # get inverted letter
+    else
+        throw(DomainError("letter has no inverse"))
+        #return nothing
+    end
+end
+
+function Base.inv(A::Alphabet, index::Integer)
+    letter = A[index]
+    if hasinverse(A, letter)
+        return A[A.inv_state[letter]] # get index of inverted letter
+    else
+        throw(DomainError("letter has no inverse"))
+        #return nothing
+    end
+end
+
+# Note: only prints indices, not elements itself
+function Base.show(io::IO, A::Alphabet{T}) where T
+    println(io, "Alphabet of $T with $(length(A)) letters:")
+    for letter in A
+        print(io, A[letter], "\t", letter)
+        if hasinverse(A, letter)
+            println(io, " with inverse ", A[inv(A, A[letter])])
+        else
+            println(io, "")
+        end
+    end
+end

--- a/src/free_group.jl
+++ b/src/free_group.jl
@@ -34,13 +34,7 @@ mutable struct FPGroupElement{G<:AbstractFPGroup, W<:AbstractWord} <: GroupEleme
 end
 
 # Pre-allocation methods
-function Base.similar(g::FPGroupElement)
-    return FPGroupElement(g.parent, similar(g.word))
-end
-
-function Base.similar(g::FPGroupElement, dim::Int)
-    return FPGroupElement(g.parent, similar(g.word, dim))
-end
+Base.similar(g::FPGroupElement, n=length(word(g))) = FPGroupElement(parent(g), similar(word(g), n))
 
 # Accessors
 Base.parent(g::FPGroupElement) = g.parent

--- a/src/free_group.jl
+++ b/src/free_group.jl
@@ -1,0 +1,113 @@
+# included from CGT_UniHeidelberg_2022.jl
+
+abstract type AbstractFPGroup{T, W} end
+
+export FreeGroup, FPGroupElement
+
+struct FreeGroup{T, W} <: AbstractFPGroup{T, W}
+    A::Alphabet{T}
+    gens::Vector{W} # stores `Word`s
+end
+
+rank(G::FreeGroup) = length(G.gens)
+
+# One may argue to use a reduced word as (representative for) a free
+# group element. From a practical (performance) perspective, I see the
+# following downsides:
+#
+# * Reduction is not lazy, e.g. the free group multiplication
+#   [w1]*[w2]*[w3] would result in 5 reductions (once for each word,
+#   once for each multiplication) instead of 2;
+#
+# * It is unclear how to pre-allocate reduced words, since the
+#   length after reduction is a-priori not known.
+#
+# As such this implementation stores an arbitrary representative (word)
+# of a free group element. Reduction can be done on-demand with the
+# mulreduce! and reduce! methods.
+#
+# Q: If a FPGroupElement is `mutable`, how useful are various `out`
+# parameters for performance reasons?
+mutable struct FPGroupElement{G<:AbstractFPGroup, W<:AbstractWord} <: GroupElement
+    parent::G
+    word::W
+end
+
+# Pre-allocation methods
+function Base.similar(g::FPGroupElement)
+    return FPGroupElement(g.parent, similar(g.word))
+end
+
+function Base.similar(g::FPGroupElement, dim::Int)
+    return FPGroupElement(g.parent, similar(g.word, dim))
+end
+
+# Accessors
+Base.parent(g::FPGroupElement) = g.parent
+word(g::FPGroupElement) = g.word
+alphabet(G::FreeGroup) = G.A
+
+# Group operations
+function mul!(out::FPGroupElement, g::FPGroupElement, h::FPGroupElement)
+    @assert parent(g) === parent(h)
+    # Note: `word` returns a mutable object bound to `g`, so this is pure sugar
+    mul!(word(out), word(g), word(h))
+    return out
+end
+
+reduce(G::FreeGroup, g::FPGroupElement) = reduce(alphabet(G), word(g))
+# XXX: use modifying reduction
+function reduce!(g::FPGroupElement)
+    g.word = reduce(parent(g), word(g))
+    return g.word
+end
+
+# Group multiplication with word reduction.
+# To allow reusing the temporary output buffer for different words (of
+# the same length), remaining entries are set to 0.
+# XXX: whether this trick results in better performance is unknown.
+function mulreduce!(out::FPGroupElement, g::FPGroupElement, h::FPGroupElement; pad=true)
+    @assert parent(g) === parent(h)
+    # concatenation
+    mul!(word(out), word(g), word(h))
+
+    # reduction (+1 allocation)
+    tmp = reduce(g.parent.A, word(out))
+    out.word[1:length(tmp)] = tmp
+
+    # optional padding
+    if pad == true
+        out.word[length(tmp):length(word(out))] .= 0
+    end
+    return out, length(tmp)
+end
+
+# Simple multiplication, with reduction only done lazly/when necessary
+function Base.:*(g::FPGroupElement, h::FPGroupElement)
+    @assert parent(g) === parent(h)
+    out = similar(g, length(word(g)) + length(word(h)))
+    out = mul!(out, word(g), word(h))
+    return FPGroupElement(out, parent(g))
+end
+
+# Group inversion
+# No reduction is performed here: if a word is reduced, then its inverse
+# is also reduced.
+function inv!(out::FPGroupElement, g::FPGroupElement)
+    @assert parent(out) === parent(g)
+    inv!(word(out), alphabet(parent(g)), word(g))
+    return out
+end
+Base.inv(g::FPGroupElement) = inv!(similar(g), g)
+
+# XXX: if words are often compared for equality, some kind of caching
+# could be implemented (e.g. as an additional field in FPGroupElement),
+# or when it is known a set of words is reduced, use == on the
+# underlying words (g.W) directly.
+function Base.:(==)(g::FPGroupElement, h::FPGroupElement)
+    @assert parent(g) === parent(h)
+    return reduce(alphabet(parent(g)), word(g)) == reduce(alphabet(parent(h)), word(h))
+end
+
+# real interesting task:
+# how and when to freely reduce the underlying words

--- a/src/word.jl
+++ b/src/word.jl
@@ -1,14 +1,97 @@
 # included from CGT_UniHeidelberg_2022.jl
 
-# Some possible methods:
-# * Is a word a generator or a relation (this does not necessarily have to be part of the struct, to save space)
-# * Is a word the identity (word problem) or reduced
-# * More generally, are two words in the same equivalence class (w ∼ z)
-# * Group multiplication / concatenation
-# * (Optional) reference to Alphabet, e.g. for word comparison
-abstract type AbstractWord{T} <: AbstractArray{T, 1} end
+export AbstractWord, Word
 
-export Word
+# AbstractWord API imported from notebooks/06_Rewriting.jl
+"""
+    AbstractWord{T} <: AbstractVector{T}
+Abstract type representing words over an Alphabet.
+
+`AbstractWord` is just a string of integers and as such gains its meaning in the
+contex of an Alphabet (when integers are understood as pointers to letters).
+The subtypes of `AbstractWord{T}` need to implement the following methods which
+constitute `AbstractWord` interface:
+ * a constructor from `AbstractVector{T}`
+ * linear indexing (1-based) consistent with iteration returning pointers to letters of an alphabet (`getindex`, `setindex!`, `size`),
+ * `Base.push!`/`Base.pushfirst!`: append a single value at the end/beginning,
+ * `Base.pop!`/`Base.popfirst!`: pop a single value from the end/beginning,
+ * `Base.append!`/`Base.prepend!`: append a another word at the end/beginning,
+ * `Base.resize!`: drop/extend a word at the end to the requested length
+ * `Base.similar`: an uninitialized word of a similar type/storage.
+
+Note that `length` represents free word (how it is written in an alphabet)
+and not its the shortest form (e.g. the normal form).
+
+!!! note
+    It is assumed that `eachindex(w::AbstractWord)` returns `Base.OneTo(length(w))`
+
+The following are implemented for `AbstractWords` but can be overloaded for
+performance reasons:
+
+* `Base.==`: the equality (as words),
+* `Base.hash`: simple uniqueness hashing function
+* `Base.:*`: word concatenation (monoid binary operation),
+"""
+abstract type AbstractWord{T} <: AbstractVector{T} end
+
+function Base.hash(w::AbstractWord, h::UInt)
+    return foldl((h, x) -> hash(x, h), w, init = hash(AbstractWord, h))
+end
+
+@inline function Base.:(==)(w::AbstractWord, v::AbstractWord)
+    length(w) == length(v) || return false
+    return all(w[i] == v[i] for i in eachindex(w))
+end
+
+# resize! + copyto!
+function store!(w::AbstractWord, v::AbstractWord)
+    resize!(w, length(v))
+    copyto!(w, v)
+    return w
+end
+
+# The identity is represented by the empty word
+Base.one(::Type{W}) where {T,W<:AbstractWord{T}} = W(T[])
+Base.one(::W) where {W<:AbstractWord} = one(W)
+Base.isone(w::AbstractWord) = isempty(w)
+
+function Base.getindex(w::W, u::AbstractRange) where {W<:AbstractWord}
+    return W([w[i] for i in u])
+end
+
+function Base.:^(w::AbstractWord, n::Integer)
+    return n >= 0 ? repeat(w, n) :
+           throw(
+        DomainError(
+            n,
+            "To rise a Word to negative power you need to provide its inverse.",
+        ),
+    )
+end
+	
+function Base.literal_pow(::typeof(^), w::AbstractWord, ::Val{p}) where {p}
+    return p >= 0 ? repeat(w, n) :
+           throw(
+        DomainError(
+            p,
+            "To rise a Word to negative power you need to provide its inverse.",
+        ),
+    )
+end
+	
+function Base.show(io::IO, ::MIME"text/plain", w::AbstractWord)
+    print(io, typeof(w), ": ")
+    return show(io, w)
+end
+
+function Base.show(io::IO, w::AbstractWord{T}) where {T}
+    if isone(w)
+        print(io, "(id)")
+    else
+        join(io, w, "·")
+    end
+end
+
 
 """ Word structure with flexible storage type (default to UInt8)
 """
@@ -23,24 +106,14 @@ end
 
 Word(idx::AbstractVector) = Word{UInt8}(idx)
 
-# AbstractArray interface
+# AbstractVector interface
 Base.size(w::Word) = size(w.letter_indices)
-Base.getindex(w::Word, i::Int) = getindex(w.letter_indices[i])
+Base.getindex(w::Word, i::Integer) = w.letter_indices[i]
+Base.setindex!(w::Word, v, i::Integer) = w.letter_indices[i] = v
 
-function Base.setindex!(w::Word, letter, i::Int)
-    w.letter_indices[i] = letter
-end
-
-# Return "mutable array"
-function Base.similar(w::Word{T}) where T
-    return Word{T}(Vector{T}(undef, length(w)))
-end
-
-function Base.similar(::Word{T}, dim::Int) where T
-    return Word{T}(Vector{T}(undef, dim))
-end
-
-Base.resize!(w::Word, n::Int) = resize!(w.letter_indices, n)
+Base.resize!(w::Word, n::Integer) = resize!(w.letter_indices, n)
+Base.similar(w::Word{T}) where T = Word{T}(similar(w.letter_indices))
+Base.similar(w::Word{T}, n::Integer) where T = Word{T}(similar(w.letter_indices, n))
 
 # * multiplication
 # When concatenating words, we can either proceed naively and
@@ -63,42 +136,27 @@ function Base.:*(w::AbstractWord, z::AbstractWord)
     return out
 end
 
-# The identity is represented by the empty word
-Base.one(::Word{T}) where T = Word{T}(T[])
-Base.isone(w::AbstractWord) = isempty(w)
-
 # Taken from 05_Alphabets_and_words.jl
 function inv!(out::AbstractWord, A::Alphabet, w::AbstractWord)
     @assert length(out) == length(w)
     for (idx, letter) in enumerate(Iterators.reverse(w))
-	out[idx] = inv(A, letter)
+	    out[idx] = inv(A, letter)
     end
     return out
 end
 Base.inv(A::Alphabet, w::AbstractWord) = inv!(similar(w), A, w)
 
-# Serialization
-function Base.show(io::IO, ::MIME"text/plain", w::AbstractWord{T}) where T
-    l = length(w)
-    for (i, letter) in enumerate(w)
-	    print(io, letter)
-	    if i < l
-	        print(io, '·')
-	    end
-    end
-end
-
-string_repr(A::Alphabet, w::AbstractWord) = join((A[idx] for idx in w), '·')
-
 # When rewriting a word to reduced form, we can use a queue approach
 # where letters followed by their inverse are removed. This is done by
 # exposing a push! and pop!-style functions.
-Base.push!(w::Word, letter_idx) = push!(w.letter_indices, letter_idx)
-Base.pushfirst!(w::Word, letter_idx) = pushfirst!(w.letter_indices, letter_idx)
 Base.pop!(w::Word) = pop!(w.letter_indices)
 Base.popfirst!(w::Word) = popfirst!(w.letter_indices)
-Base.append!(w::Word, letter_idx) = append!(w.letter_indices, letter_idx)
-Base.prepend!(w::Word, letter_idx) = prepend!(w.letter_indices, letter_idx)
+
+Base.push!(w::Word, n::Integer) = push!(w.letter_indices, n)
+Base.pushfirst!(w::Word, n::Integer) = pushfirst!(w.letter_indices, n)
+
+Base.append!(w::Word, v::AbstractWord) = append!(w.letter_indices, v)
+Base.prepend!(w::Word, v::AbstractWord) = prepend!(w.letter_indices, v)
 
 # Rewriting rules:
 # * xsŝy → xy  [1]

--- a/src/word.jl
+++ b/src/word.jl
@@ -1,0 +1,134 @@
+# included from CGT_UniHeidelberg_2022.jl
+
+# Some possible methods:
+# * Is a word a generator or a relation (this does not necessarily have to be part of the struct, to save space)
+# * Is a word the identity (word problem) or reduced
+# * More generally, are two words in the same equivalence class (w ∼ z)
+# * Group multiplication / concatenation
+# * (Optional) reference to Alphabet, e.g. for word comparison
+abstract type AbstractWord{T} <: AbstractArray{T, 1} end
+
+export Word
+
+""" Word structure with flexible storage type (default to UInt8)
+"""
+struct Word{T} <: AbstractWord{T}
+    letter_indices::Vector{T}
+
+    function Word{T}(idx::AbstractVector) where T
+        w = new(idx)
+        return w
+    end
+end
+
+Word(idx::AbstractVector) = Word{UInt8}(idx)
+
+# AbstractArray interface
+Base.size(w::Word) = size(w.letter_indices)
+Base.getindex(w::Word, i::Int) = getindex(w.letter_indices[i])
+
+function Base.setindex!(w::Word, letter, i::Int)
+    w.letter_indices[i] = letter
+end
+
+# Return "mutable array"
+function Base.similar(w::Word{T}) where T
+    return Word{T}(Vector{T}(undef, length(w)))
+end
+
+function Base.similar(::Word{T}, dim::Int) where T
+    return Word{T}(Vector{T}(undef, dim))
+end
+
+Base.resize!(w::Word, n::Int) = resize!(w.letter_indices, n)
+
+# * multiplication
+# When concatenating words, we can either proceed naively and
+# concatenate both words, or we can try to make reduction in the
+# process, i.e. by the rules:
+#  - ysŝx ∼ yx
+#  - yŝsx ∼ yx
+# In the former case, we do not need an Alphabet, but the length of
+# `out` is not known a-priori.
+function mul!(out::AbstractWord, w::AbstractWord, z::AbstractWord)
+    resize!(out, length(w)+length(z))
+    copyto!(out, 1, w, 1, length(w))
+    copyto!(out, length(w)+1, z, 1, length(z))
+    return out
+end
+
+function Base.:*(w::AbstractWord, z::AbstractWord)
+    out = similar(w, length(w) + length(z))
+    mul!(out, w, z)
+    return out
+end
+
+# The identity is represented by the empty word
+Base.one(::Word{T}) where T = Word{T}(T[])
+Base.isone(w::AbstractWord) = isempty(w)
+
+# Taken from 05_Alphabets_and_words.jl
+function inv!(out::AbstractWord, A::Alphabet, w::AbstractWord)
+    @assert length(out) == length(w)
+    for (idx, letter) in enumerate(Iterators.reverse(w))
+	out[idx] = inv(A, letter)
+    end
+    return out
+end
+Base.inv(A::Alphabet, w::AbstractWord) = inv!(similar(w), A, w)
+
+# Serialization
+function Base.show(io::IO, ::MIME"text/plain", w::AbstractWord{T}) where T
+    l = length(w)
+    for (i, letter) in enumerate(w)
+	    print(io, letter)
+	    if i < l
+	        print(io, '·')
+	    end
+    end
+end
+
+string_repr(A::Alphabet, w::AbstractWord) = join((A[idx] for idx in w), '·')
+
+# When rewriting a word to reduced form, we can use a queue approach
+# where letters followed by their inverse are removed. This is done by
+# exposing a push! and pop!-style functions.
+Base.push!(w::Word, letter_idx) = push!(w.letter_indices, letter_idx)
+Base.pushfirst!(w::Word, letter_idx) = pushfirst!(w.letter_indices, letter_idx)
+Base.pop!(w::Word) = pop!(w.letter_indices)
+Base.popfirst!(w::Word) = popfirst!(w.letter_indices)
+Base.append!(w::Word, letter_idx) = append!(w.letter_indices, letter_idx)
+Base.prepend!(w::Word, letter_idx) = prepend!(w.letter_indices, letter_idx)
+
+# Rewriting rules:
+# * xsŝy → xy  [1]
+# * xŝsy → xy  [2]
+function Base.reduce(A::Alphabet, w::Word)
+    queue = similar(w, 0)
+    cnt = 1
+
+    # go over each element of the input word
+    while cnt <= length(w)
+        idx1 = w[cnt]
+        cnt += 1
+
+        if length(queue) > 0
+            idx2 = queue[length(queue)] # previous element
+            l1 = A[idx1]  # returns Alphabet[index] → letter{T}
+            l2 = A[idx2]
+
+            if (l1 == inv(A, l2)) || (l2 == inv(A, l1))
+                # remove previous letter from input queue
+                pop!(queue)
+            else
+                # otherwise, push the new letter for processing
+                push!(queue, idx1)
+            end
+        else
+            push!(queue, idx1)
+        end
+    end
+    return queue
+end
+
+# BufferWord (deque)

--- a/test/alphabet.jl
+++ b/test/alphabet.jl
@@ -1,0 +1,42 @@
+@testset "Alphabet API" begin 
+    σ = Permutation([2,1,3])
+    τ = Permutation([1,3,2])
+    A = Alphabet{Permutation}([σ, τ])
+    
+    # Cycles are self-inverse. In this case, the Alphabet constructor should
+    # throw an exception.
+    @test_throws AssertionError Alphabet{Permutation}([σ, inv(σ), τ, inv(τ)])
+    # We do not allow alphabets of integers.
+    @test_throws AssertionError Alphabet{Int64}([1, 2, 3])
+
+    @test length(A) == 2
+    @test A[1] == σ
+    @test A[2] == τ
+    @test A[σ] == 1
+    @test A[τ] == 2
+
+    κ = Permutation([2,1,3,5,4])
+    # Invalid element access
+    @test_throws AssertionError A[3]
+    @test_throws AssertionError A[κ]
+
+    # Inverse is not defined a-priori
+    @test !hasinverse(A, σ)
+    @test_throws DomainError inv(A, σ)
+    @test_throws DomainError inv(A, 1)
+
+    setinverse!(A, σ, σ) # σ is a cycle
+    @test hasinverse(A, σ)
+    @test inv(A, σ) == σ
+    @test inv(A, 1) == A[σ]
+
+    @test !hasinverse(A, τ)
+    @test_throws DomainError inv(A, τ)
+    @test_throws DomainError inv(A, 2)
+
+    setinverse!(A, τ, τ) # τ is a cycle
+    @test hasinverse(A, τ)
+    @test inv(A, τ) == inv(τ)
+    @test inv(A, A[τ]) == A[inv(τ)]
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ include("small_perm_groups.jl")
     include("transversals.jl")
     include("schreier_sims.jl")
     include("alphabet.jl")
+    include("word.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,14 @@ import CGT_UniHeidelberg_2022:
     CyclePermutation,
     CyclePermutation2,
     Orbit,
-    Transversal
+    Transversal,
+    Alphabet
 
 include("small_perm_groups.jl")
 
 @testset verbose=true "CGT" begin
-   include("permutations.jl")
-   include("transversals.jl")
-   include("schreier_sims.jl")
+    include("permutations.jl")
+    include("transversals.jl")
+    include("schreier_sims.jl")
+    include("alphabet.jl")
 end

--- a/test/word.jl
+++ b/test/word.jl
@@ -1,0 +1,49 @@
+@testset "Word API" begin
+    # Construct alphabet
+    σ = Permutation([2,1,3])
+    τ = Permutation([1,3,2])
+    A = Alphabet{Permutation}([σ, τ])
+    setinverse!(A, σ, σ)
+    setinverse!(A, τ, τ)
+
+    # Word indices
+    idx1 = [1, 1, 2, 1, 2, 2]
+    idx2 = [2, 1]
+    idx3 = [2]
+    idx4 = [1, 1, 2, 1, 1, 2]
+
+    W1 = Word(idx1);
+    W2 = Word(idx2);
+    W3 = Word(idx3);
+    W4 = Word(idx4);
+
+    # Check default type is UInt8
+    @test eltype(W1) == UInt8;
+
+    @testset "Word operations" begin
+        # Multiplication
+        W11 = W1 * W1;
+        @test length(W11) == length(W1)*2
+        @test collect(W11) == [collect(W1); collect(W1)]
+        @test W11 == repeat(W1, 2) # this guy is a `Word`!
+        @test isempty(one(W1))
+
+        # Inverses
+        # Note: elements in A are self-inverse
+        @test inv(A, W1) == Word([2, 2, 1, 2, 1, 1])
+        @test inv(A, W2) == Word([1, 2])
+        @test inv(A, W3) == Word([2])
+        @test inv(A, W4) == Word([2, 1, 1, 2, 1, 1])
+
+        # Reduction
+        @test reduce(A, W1) == Word([2, 1])
+        @test reduce(A, W2) == Word([2, 1])
+        @test reduce(A, W3) == Word([2])
+        @test reduce(A, W4) == one(W4)
+
+        @test reduce(A, W1 * inv(A, W1)) == one(W1)
+        @test reduce(A, W2 * inv(A, W2)) == one(W2)
+        @test reduce(A, W3 * inv(A, W3)) == one(W3)
+        @test reduce(A, W4 * inv(A, W4)) == one(W4)
+    end
+end


### PR DESCRIPTION
Work towards Exercise 1-3 of `05_Alphabets_and_words.jl` you sent us.

- [x] Exercise 1 - Alphabets (`src/alphabet.jl`)
   - [x] `struct Alphabet{T}`
   - [x] Iterator interface (`Base.iterate`, `Base.length`)
   - [x] Indexing (`Base.getindex` for `Integer` and `letter:T`)
   - [x] Inverses (`hasinverse`, `setinverse!`, `Base.inv`)
   - [x] I/O (`Base.show` taken from the worksheet)
   - [x] Tests (`test/alphabet.jl`)

- [x] Exercise 2 - Words (`src/word.jl`)
   - [x] `struct Word{T}` with default `UInt8` storage
   - [x] `AbstractVector` interface (`Base.size`, `Base.getindex`, `Base.setindex!`)
   - [x] Iterator interface (`Base.iterate`, `Base.length`)
   - [x] Multiplication (`Base.:*`), identity (`Base.one`)
   - [x] Inverses (`inv!` taken from worksheet, `Base.similar`)
   - [x] I/O (`Base.show` taken from worksheet, `string_repr` has an error)
   - [x] Tests (`tests/word.jl`)

- [ ] Exercise 3 - Free groups (`src/free_group.jl`)
   - [x] `FreeGroup`
   - [x] `FPGroupElem`
   - [x] Multiplication
   - [x] Inversion
   - [x] Solve the word problem
   - [ ] Tests (`tests/free_group.jl`)

I've also implemented `Base.startswith` and `Base.occursin` for `Word`, as it seems they might become useful later on (small cancellation?). 

`Word` compiles, but there are no tests for it yet (I wrote some for `Alphabet`).